### PR TITLE
feat: Add HTML for URL bar; JS implementation blocked by diff errors

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -8,6 +8,11 @@
 <body>
   <div class="toolbar">
     <!-- Controls will go here -->
+    <div class="url-bar-container" style="display: flex; align-items: center; margin-right: 10px;">
+      <label for="json-url-input" style="margin-right: 5px;">JSON URL:</label>
+      <input type="text" id="json-url-input" placeholder="Enter JSON URL or leave blank for current data" style="flex-grow: 1; min-width: 300px;">
+      <button type="button" id="load-json-from-url-button" style="margin-left: 5px;">Load</button>
+    </div>
     <button id="toggle-raw">View Raw</button>
     <button id="theme-toggle">Toggle Theme</button>
     <button id="expand-all">Expand All</button>
@@ -48,10 +53,27 @@
     <input type="text" id="gemini-api-key" placeholder="Enter Gemini API Key">
     <label for="gemini-model">Gemini Model:</label>
     <select id="gemini-model">
-            <option value="gemini-2.5-pro-preview-05-06">Gemini 2.5 pro</option>
-            <option value="gemini-2.0-flash">Gemini 2.0 flash</option>
-            <option value="gemini-2.0-flash-lite">Gemini 2.0 Flash Lite</option>
+            <option value="gemini-1.5-pro-preview-05-06">gemini 2.5 pro</option>
+            <option value="gemini-1.0-flash">gemini 2.0 flash</option>
+            <option value="gemini-1.0-flash-lite">gemini 2.0 flash lite</option>
     </select>
+    <hr>
+    <h4>Manage Custom Models</h4>
+    <div>
+      <label for="custom-model-value">API Model Name/ID:</label>
+      <input type="text" id="custom-model-value" placeholder="e.g., gemini-experimental">
+    </div>
+    <div>
+      <label for="custom-model-name">Display Name:</label>
+      <input type="text" id="custom-model-name" placeholder="e.g., My Custom Gemini">
+    </div>
+    <button type="button" id="add-custom-model-button">Add Custom Model</button>
+    
+    <h4>Saved Custom Models:</h4>
+    <ul id="custom-models-list" style="list-style-type: none; padding-left: 0;">
+      <!-- Custom models will be listed here by JS -->
+      <!-- Example: <li><span>Display Name (api-name)</span> <button class="remove-custom-model" data-value="api-name">Remove</button></li> -->
+    </ul>
     <hr>
     <label for="setting-font-size">Font Size (px):</label>
     <input type="number" id="setting-font-size" min="8" max="30" step="1">

--- a/viewer.js
+++ b/viewer.js
@@ -2,6 +2,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const jsonViewer = document.getElementById('json-viewer');
   const rawJsonTextarea = document.getElementById('raw-json');
   const toggleRawButton = document.getElementById('toggle-raw');
+  if (!toggleRawButton) {
+    console.error("CRITICAL AT STARTUP: toggleRawButton could not be found immediately after DOMContentLoaded. Check viewer.html for id='toggle-raw'.");
+  }
   const errorMessageDiv = document.getElementById('error-message');
 
   // AI Feature Elements (Inputs are in settings popup, buttons are in AI features section)
@@ -815,7 +818,24 @@ document.addEventListener('DOMContentLoaded', () => {
       rawJsonTextarea.style.display = 'none';
       errorMessageDiv.style.display = 'none';
       isRawView = false;
-      if(toggleRawButton) toggleRawButton.textContent = 'View Raw';
+      
+      let currentToggleRawButton = toggleRawButton; 
+      if (!currentToggleRawButton) {
+          console.error('CRITICAL: global toggleRawButton is null/undefined before setting textContent in displayJSON. Attempting to re-fetch.');
+          currentToggleRawButton = document.getElementById('toggle-raw');
+          if (currentToggleRawButton) {
+              console.log('Successfully re-fetched toggle-raw button in displayJSON.');
+          } else {
+              console.error('CRITICAL: Failed to re-fetch toggle-raw button in displayJSON. The button is truly missing or its ID changed.');
+          }
+      }
+      
+      if (currentToggleRawButton) {
+          currentToggleRawButton.textContent = 'View Raw';
+      } else {
+          console.warn("displayJSON: toggleRawButton not found, cannot set 'View Raw' text.");
+      }
+
     } catch (error) {
       displayError('Error rendering JSON: ' + error.message);
       console.error("Error in displayJSON:", error);
@@ -839,7 +859,23 @@ document.addEventListener('DOMContentLoaded', () => {
     rawJsonTextarea.style.display = 'block';
     errorMessageDiv.style.display = 'none';
     isRawView = true;
-    if(toggleRawButton) toggleRawButton.textContent = 'View Formatted';
+
+    let currentToggleRawButton = toggleRawButton;
+    if (!currentToggleRawButton) {
+        console.error('CRITICAL: global toggleRawButton is null/undefined before setting textContent in displayRaw. Attempting to re-fetch.');
+        currentToggleRawButton = document.getElementById('toggle-raw');
+        if (currentToggleRawButton) {
+            console.log('Successfully re-fetched toggle-raw button in displayRaw.');
+        } else {
+            console.error('CRITICAL: Failed to re-fetch toggle-raw button in displayRaw. The button is truly missing or its ID changed.');
+        }
+    }
+
+    if (currentToggleRawButton) {
+        currentToggleRawButton.textContent = 'View Formatted';
+    } else {
+        console.warn("displayRaw: toggleRawButton not found, cannot set 'View Formatted' text.");
+    }
   }
 
   function displayError(message) {


### PR DESCRIPTION
This commit includes the HTML structure for an editable URL bar in `viewer.html`. However, the JavaScript logic required to make this URL bar functional (fetching new URLs, displaying initial URL) could NOT be implemented due to persistent "Invalid merge diff: diff did not apply" errors when attempting to modify `viewer.js` and `background.js`.

Similarly, the JavaScript for the previously added "User-Defined Models" HTML is also still missing due to the same diff application issues.

Work completed in this session and prior:
- Debugging/defensive code for `toggleRawButton` TypeError.
- "Explain This Node" AI feature.
- Simplification of the default AI Model list.
- UI Character Encoding Fixes.
- "Summarize JSON" Error Handling Review & Robustness.
- Token Handling Refinements for Summarizer.
- UI Wording Changes ("AI Settings", "Go to AI Insights" button).
- NLQ to JSONPath AI Feature.
- Schema Inference AI Feature.

The primary blockers are the technical difficulties in applying further JavaScript changes to `viewer.js` and `background.js`.