### PR TITLE
fix: Resolve URIError when parsing JSON from URL parameters

### DIFF
--- a/viewer.js
+++ b/viewer.js
@@ -2034,21 +2034,18 @@ Summary:`;
         }
       });
     } else if (jsonParam) {
-      console.log('[viewer.js] Received jsonParam from URL (raw, before decode):', jsonParam);
+      // console.log('[viewer.js] Received jsonParam from URL (raw, before decode):', jsonParam); // Kept for now, can be removed later
       console.log('Attempting to load JSON from URL parameter.');
+      console.log('[viewer.js] jsonParam received (will be used directly for JSON.parse):', jsonParam);
       try {
-        console.log('[viewer.js] jsonParam right before decodeURIComponent:', jsonParam);
-        const decodedJson = decodeURIComponent(jsonParam);
-        console.log('[viewer.js] jsonParam after decodeURIComponent:', decodedJson);
-        const jsonData = JSON.parse(decodedJson);
+        // const decodedJson = decodeURIComponent(jsonParam); // REMOVED
+        // console.log('[viewer.js] jsonParam after decodeURIComponent:', decodedJson); // REMOVED
+        const jsonData = JSON.parse(jsonParam); // CHANGED: use jsonParam directly
         displayJSON(jsonData);
       } catch (e) {
         console.error('Error parsing JSON from URL parameter:', e);
-        // Ensure decodedJson is defined in this scope if an error occurs during decodeURIComponent itself
-        // However, the most likely error is JSON.parse, where decodedJson would be available.
-        const decodedContentForError = (typeof decodedJson !== 'undefined') ? decodedJson : jsonParam;
-        console.error('[viewer.js] Content that failed JSON.parse (or was problematic before parse):', decodedContentForError);
-        displayError(`Error parsing JSON from URL: ${e.message}`);
+        console.error('[viewer.js] Content that failed JSON.parse:', jsonParam); // CHANGED: use jsonParam
+        displayError(`Error parsing JSON from URL: ${e.message} (Raw param snippet: ${jsonParam.substring(0,100)}...)`);
       }
     } else {
       console.log('No storageKey or json URL parameter found. Loading sample JSON.');


### PR DESCRIPTION
This commit fixes a "URIError: URI malformed" that occurred in `viewer.js` when attempting to load JSON content passed as a URL parameter (e.g., `?json=...`).

The issue was caused by `viewer.js` calling `decodeURIComponent()` on the `jsonParam` extracted from the URL. Logs revealed that `jsonParam` was already the plain, decoded JSON string (likely decoded by the browser or URLSearchParams API automatically). Calling `decodeURIComponent()` again on this already-decoded string resulted in the error.

The fix involves:
- Removing the redundant `decodeURIComponent(jsonParam)` call in `viewer.js`.
- Using the `jsonParam` directly for `JSON.parse()`.
- Adjusting related console logging.

This change should allow correct parsing of JSON data passed via URL parameters, as demonstrated with the npoint.io test case.

All previously implemented features (Editable URL Bar, User-Defined Models, AI features, performance safeguards, etc.) are included.